### PR TITLE
Use the SPDX license identifier, update url

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,8 +14,8 @@
 
   <licenses>
     <license>
-      <name>The MIT License(MIT)</name>
-      <url>http://opensource.org/licenses/MIT</url>
+      <name>MIT</name>
+      <url>https://opensource.org/license/MIT</url>
     </license>
   </licenses>
 


### PR DESCRIPTION
This changes the license `name` to use the SPDX identifier for MIT, as recommended in the Maven POM reference: https://maven.apache.org/pom.html#Licenses 

Also update the `url` to the license.

This will make it easier for automated tools to recognise the proper license.